### PR TITLE
getNetworks, addDeployment, removeDeployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,17 @@ getZones(args)
 getZone(uri, args)
 getRates(args)
 getRate(uri, args)
+getNetworks(args)
 
 getProjects(args)
 getProject(uri, args)
 addProject(data, args)
 updateProject(uri, data, args)
 removeProject(uri, args)
+createDeployment(args)
 getDeployments(args)
 getDeployment(uri, args)
+removeDeployment(uri, args)
 getMetrics(args)
 ```
 

--- a/__tests__/__snapshots__/admin.spec.js.snap
+++ b/__tests__/__snapshots__/admin.spec.js.snap
@@ -1,41 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`rollie Add, update and remove project 1`] = `
-Array [
-  "id",
-  "name",
-  "description",
-  "uri",
-  "modified",
-  "tagUris",
-  "protected",
-]
-`;
-
-exports[`rollie Add, update and remove project 2`] = `
-Array [
-  "id",
-  "name",
-  "description",
-  "uri",
-  "modified",
-  "tagUris",
-  "protected",
-]
-`;
-
-exports[`rollie Add, update and remove project 3`] = `
-Array [
-  "id",
-  "name",
-  "description",
-  "uri",
-  "modified",
-  "tagUris",
-  "protected",
-]
-`;
-
 exports[`rollie Add, update and remove user 1`] = `
 Array [
   "id",
@@ -63,5 +27,21 @@ Array [
   "name",
   "uri",
   "role",
+]
+`;
+
+exports[`rollie Create and delete deployment 1`] = `
+Array [
+  "id",
+  "name",
+  "zoneUri",
+  "regionUri",
+  "virtualMachineProfileUri",
+  "status",
+  "uri",
+  "projectUri",
+  "hasConsole",
+  "created",
+  "modified",
 ]
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -317,6 +317,13 @@ export default class OneSphere {
     return fetcher(`${this.host}${uri}${params}`, { headers: this.headers });
   }
 
+  // networks
+
+  getNetworks(args) {
+    const params = getUrlParams(args);
+    return fetcher(`${this.host}/rest/networks${params}`, { headers: this.headers });
+  }
+
   // projects
 
   getProjects(args) {
@@ -349,6 +356,12 @@ export default class OneSphere {
 
   // deployments
 
+  addDeployment(data, args) {
+    const options = this.postOptions(data);
+    const params = getUrlParams(args);
+    return fetcher(`${this.host}/rest/deployments${params}`, options);
+  }
+
   getDeployments(args) {
     const params = getUrlParams(args);
     return fetcher(`${this.host}/rest/deployments${params}`, { headers: this.headers });
@@ -357,6 +370,12 @@ export default class OneSphere {
   getDeployment(uri, args) {
     const params = getUrlParams(args);
     return fetcher(`${this.host}${uri}${params}`, { headers: this.headers });
+  }
+
+  removeDeployment(uri, args) {
+    const options = { headers: this.headers, method: 'DELETE' };
+    const params = getUrlParams(args);
+    return fetcher(`${this.host}${uri}${params}`, options);
   }
 
   // metrics


### PR DESCRIPTION
Hello,

Here's some code that implements removeDeployment. To test this function, I had to implement addDeployment and getNetworks to remove a deployment created in the tests.

Regarding the code, I'm wondering if we should have the method called `addDeployment`or `createDeployment`. We don't really "add" a deployment, however, all the other calls are with "add".

Regarding the test, I'm not sure that's the correct way to implement it. There are prerequisites for this test to pass, so it will not work on any OneSphere instance.
You need to have:
- a vCenter provider
- a template (on this vCenter) that fits one of the profiles provided by oneSphere ([vm profiles](https://developer.hpe.com/api/onesphere/endpoint?&path=%2Fvirtual-machine-profiles))
- networks associated to the vCenter provider

Also, using OneSphere SaaS I've seen that Networks need to be exposed/attached to projects so you can deploy them. I didn't attached the network found on the vCenter provider to the newly created project (`Api Test Deployment` in `beforeAll()`). So I guess this is only a front-end check and I'm not sure it'll stay that way...

This worked on my OneSphere instance but it might not on others because I made assumptions and used existing entities that were not deployed in the tests.

I'm open to any remarks that'll make this test more robust and/or portable.